### PR TITLE
Add -p option for progress meter in RAID scripts

### DIFF
--- a/RAID/recover_raid
+++ b/RAID/recover_raid
@@ -21,8 +21,27 @@
 
 # Recover any failed and/or missing devices back into an active RAID
 
-if [ $# -gt 0 ]; then
-	raid=/dev/$1
+usage() {
+	echo "Usage: $0 [-p]"
+	echo -e "  where\t-h\tdisplay this help and exit"
+	echo -e "  \t-p\tdisplay prgress meter while recovering"
+}
+
+PROGRESS_METER=0
+while getopts "hp" arg; do
+	case $arg in
+		p)
+			PROGRESS_METER=1
+			;;
+		h | *)
+			usage
+			exit 0
+			;;
+	esac
+done
+ARG1=${@:$OPTIND:1}
+if [ "$ARG1" ]; then
+	raid="/dev/$ARG1"
 else
 	raid=/dev/md0
 fi
@@ -82,7 +101,6 @@ else
 	echo "Re-adding missing device(s) to RAID array $raid ... "
 	mdadm $raid --re-add missing
 fi
-echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
 sleep 1
 
 mdadm --detail $raid; echo
@@ -91,14 +109,19 @@ if ! mdadm --detail $raid | grep -q ", recovering $"; then
 	exit 1
 fi
 
-while ! grep -q recovery /proc/mdstat; do 
-	echo "Waiting for recovery ..."
-	sleep 1;
-done
+if [ "$PROGRESS_METER" -ne 0 ]; then
+	echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
+	while ! grep -q recovery /proc/mdstat; do
+		echo "Waiting for recovery ... "
+		sleep 1;
+	done
 #
-while grep -q recovery /proc/mdstat; do 
-	recovery=$(grep recovery /proc/mdstat | cut -c32-)
-	echo -e -n "\r$recovery"
-	sleep 1;
-done
-echo -e "\ndone."
+	while grep -q recovery /proc/mdstat; do
+		recovery=$(grep recovery /proc/mdstat | cut -c32-)
+		echo -e -n "\r$recovery"
+		sleep 1;
+	done
+	echo -e "\ndone."
+else
+	echo "You check on the recovery progress with 'mdstat'."
+fi

--- a/RAID/recover_raid
+++ b/RAID/recover_raid
@@ -123,5 +123,5 @@ if [ "$PROGRESS_METER" -ne 0 ]; then
 	done
 	echo -e "\ndone."
 else
-	echo "You check on the recovery progress with 'mdstat'."
+	echo "You can check on the recovery progress with 'mdstat'."
 fi

--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -255,6 +255,6 @@ if [ "$PROGRESS_METER" -ne 0 ]; then
 	done
 	echo -e "\ndone."
 else
-	echo "You check on the recovery progress with 'mdstat'."
+	echo "You can check on the recovery progress with 'mdstat'."
 
 fi

--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -23,13 +23,22 @@
 # the second disk (if missing), rebuilds the boot sector and adds the RAID
 # partition back into the array as a spare to be rebuilt.
 
-usage() { echo "Usage: $0 [-A][-h]"; echo -e "  where\t-A\tAllow \"Secondary\" disk to be loaded at start"; echo -e "  \t-h\tdisplay this help and exit"; }
+usage() {
+	echo "Usage: $0 [-A][-h][-p]"
+	echo -e "  where\t-A\tAllow \"Secondary\" disk to be loaded at start"
+	echo -e "  \t-h\tdisplay this help and exit"
+	echo -e "  \t-p\tdisplay prgress meter while recovering"
+}
 
 ACCEPT_LOAD=0
-while getopts "Ah" arg; do
+PROGRESS_METER=0
+while getopts "Ahp" arg; do
 	case $arg in
 		A)
 			ACCEPT_LOAD=1
+			;;
+		p)
+			PROGRESS_METER=1
 			;;
 		h | *)
 			usage
@@ -218,7 +227,6 @@ fi
 
 # Then add the Secondary RAID partition as a replacement into the RAIO
 echo "Adding \"Secondary\" disk $part2 to RAID array /dev/md0 ... "
-echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
 mdadm --zero-superblock $part2 2> /dev/null	# will fail if disk is blank
 mdadm /dev/md0 --add-spare $part2
 sleep 1
@@ -233,14 +241,20 @@ fi
 rm -f $lockf
 
 # Finally report on recovery progress until it completes
-while ! grep -q recovery /proc/mdstat; do 
-	echo "Waiting for recovery ... "
-	sleep 1;
-done
+if [ "$PROGRESS_METER" -ne 0 ]; then
+	echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
+	while ! grep -q recovery /proc/mdstat; do
+		echo "Waiting for recovery ... "
+		sleep 1;
+	done
 #
-while grep -q recovery /proc/mdstat; do 
-	recovery=$(grep recovery /proc/mdstat | cut -c32-)
-	echo -e -n "\r$recovery"
-	sleep 1;
-done
-echo -e "\ndone."
+	while grep -q recovery /proc/mdstat; do
+		recovery=$(grep recovery /proc/mdstat | cut -c32-)
+		echo -e -n "\r$recovery"
+		sleep 1;
+	done
+	echo -e "\ndone."
+else
+	echo "You check on the recovery progress with 'mdstat'."
+
+fi


### PR DESCRIPTION
This is a first stab at moving the recovery progress meter to an option so that control-C is not needed for normal operations.  _refresh_secondary_ has been tested. _recover_raid_ has not been fully tested, but the final clause is identical to the one in _refresh_secondary_. _recovery_raid_ will be tested more later.

If this looks like it is going in an adequate direction, I can prepare an update of the documents.

One thing that that occurs to me is that it might be good if there were a positive statement that the recovery is proceeding when there is no progress report. I'll push something for that later, reusing some of the progress report clause code.