### PR TITLE
Add rotation_shutdown

### DIFF
--- a/RAID/install_tools
+++ b/RAID/install_tools
@@ -53,4 +53,9 @@ cd /usr/local/sbin
 cp -a ~/fsl11/RAID/drop_primary .
 chown root:root drop_primary
 chmod a+r,u+x,go-wx drop_primary
+echo "setting up rotation_shutdown"
+cd /usr/local/sbin
+cp -a ~/fsl11/RAID/rotation_shutdown .
+chown root:root rotation_shutdown
+chmod a+r,u+x,go-wx rotation_shutdown
 echo "done"

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -53,8 +53,9 @@ if mdadm --detail /dev/md0 | grep -q ", recovering $"; then
 			echo -e -n "\r$recovery"
 			sleep 1;
 		done
-		echo -e "\nERROR: Recovery finished. You can try '$0' again without -p."
-		exit 1
+		echo -e "\nRecovery finished."
+		echo "You can try '$0' again without '-p'."
+		exit 0
 	else
 		echo -e "ERROR: RAID is recovering. Check progress with 'mdstat'. NOT safe to rotate disks."
 		exit 1
@@ -63,6 +64,13 @@ elif mdadm --detail /dev/md0 2>&1 | grep -q "degraded" ; then
 	echo "ERROR: RAID is degraded (and probably not recovering). NOT safe to rotate disks."
 	exit 1
 fi
+
+if [ "$PROGRESS_METER" -ne 0 ]; then
+	echo "RAID not degraded and not recovering."
+	echo "You can try '$0' again without '-p'."
+	exit 0
+fi
+
 echo "RAID not degraded and not recovering. SAFE to rotate disks. Shutting down ..."
 sync;sync
 sleep 1;

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -40,19 +40,14 @@ while getopts "hp" arg; do
 	esac
 done
 
-if mdadm --detail /dev/md0 2>&1 | grep -q ", degraded $" ; then
-	echo "ERROR: RAID is degraded (and not recovering). Can't start rotation."
-	exit 1
-fi
-
-if grep -q recovery /proc/mdstat; then
+if mdadm --detail /dev/md0 | grep -q ", recovering $"; then
 	if [ "$PROGRESS_METER" -ne 0 ]; then
 		echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
-	fi
-	recovery=$(grep recovery /proc/mdstat | cut -c32-)
-	echo -e -n "\r$recovery"
-
-	if [ "$PROGRESS_METER" -ne 0 ]; then
+		while ! grep -q recovery /proc/mdstat; do
+			echo "Waiting for recovery ... "
+			sleep 1;
+		done
+#
 		while grep -q recovery /proc/mdstat; do
 			recovery=$(grep recovery /proc/mdstat | cut -c32-)
 			echo -e -n "\r$recovery"
@@ -61,9 +56,12 @@ if grep -q recovery /proc/mdstat; then
 		echo -e "\nERROR: Recovery finished. You can try '$0' again without -p."
 		exit 1
 	else
-		echo -e "\nERROR: RAID is recovering. Can't start rotation. Try again later."
+		echo -e "ERROR: RAID is recovering. Can't start rotation. Try again later."
 		exit 1
 	fi
+elif mdadm --detail /dev/md0 2>&1 | grep -q "degraded" ; then
+	echo "ERROR: RAID is degraded (and not recovering). Can't start rotation."
+	exit 1
 fi
 echo "RAID not degraded and not recovering. Shutting down for rotation."
 sync;sync

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 NVI, Inc.
+#
+# This file is part of FSL10 Linux distribution.
+# (see http://github.com/nvi-inc/fsl11).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# For systems with GPT LVM RAID arrays, copies the partition table onto
+# the second disk (if missing), rebuilds the boot sector and adds the RAID
+# partition back into the array as a spare to be rebuilt.
+
+set -e
+
+usage() {
+	echo "Usage: $0 [-A][-h][-p]"
+	echo -e "  \t-h\tdisplay this help and exit"
+	echo -e "  \t-p\tdisplay prgress meter if recovering"
+}
+
+PROGRESS_METER=0
+while getopts "Ahp" arg; do
+	case $arg in
+		p)
+			PROGRESS_METER=1
+			;;
+		h | *)
+			usage
+			exit 0
+			;;
+	esac
+done
+
+if mdadm --detail /dev/md0 2>&1 | grep -q ", degraded $" ; then
+	echo "ERROR: RAID is degraded (and not recovering). Can't start rotation."
+	exit 1
+fi
+
+if grep -q recovery /proc/mdstat; then
+	if [ "$PROGRESS_METER" -ne 0 ]; then
+		echo "(This may safely be interrupted with 'Control-C' if you don't want to wait)"
+	fi
+	recovery=$(grep recovery /proc/mdstat | cut -c32-)
+	echo -e -n "\r$recovery"
+
+	if [ "$PROGRESS_METER" -ne 0 ]; then
+		while grep -q recovery /proc/mdstat; do
+			recovery=$(grep recovery /proc/mdstat | cut -c32-)
+			echo -e -n "\r$recovery"
+			sleep 1;
+		done
+		echo -e "\nERROR: Recovery finished. You can try '$0' again without -p."
+                exit 1
+        else
+                echo -e "\nERROR: RAID is recoverying. Can't start rotation. Try again later."
+                exit 1
+        fi
+fi
+echo "RAID not degraded and not recoverying. Shutting down for rotation."
+sync;sync
+sleep 1;
+shutdown -h now

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -19,20 +19,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-# For systems with GPT LVM RAID arrays, copies the partition table onto
-# the second disk (if missing), rebuilds the boot sector and adds the RAID
-# partition back into the array as a spare to be rebuilt.
-
 set -e
 
 usage() {
-	echo "Usage: $0 [-A][-h][-p]"
+	echo "Usage: $0 [-h][-p]"
 	echo -e "  \t-h\tdisplay this help and exit"
-	echo -e "  \t-p\tdisplay prgress meter if recovering"
+	echo -e "  \t-p\tdisplay progress meter if recovering"
 }
 
 PROGRESS_METER=0
-while getopts "Ahp" arg; do
+while getopts "hp" arg; do
 	case $arg in
 		p)
 			PROGRESS_METER=1
@@ -63,13 +59,13 @@ if grep -q recovery /proc/mdstat; then
 			sleep 1;
 		done
 		echo -e "\nERROR: Recovery finished. You can try '$0' again without -p."
-                exit 1
-        else
-                echo -e "\nERROR: RAID is recoverying. Can't start rotation. Try again later."
-                exit 1
-        fi
+		exit 1
+	else
+		echo -e "\nERROR: RAID is recovering. Can't start rotation. Try again later."
+		exit 1
+	fi
 fi
-echo "RAID not degraded and not recoverying. Shutting down for rotation."
+echo "RAID not degraded and not recovering. Shutting down for rotation."
 sync;sync
 sleep 1;
 shutdown -h now

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -92,6 +92,7 @@ else
 fi
 
 echo "RAID not degraded and not recovering. SAFE to rotate disks. Shutting down ..."
+sleep 2;
 sync;sync
 sleep 1;
 shutdown -h now

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -24,7 +24,7 @@ set -e
 usage() {
 	echo "Usage: $0 [-h][-p]"
 	echo -e "  \t-h\tdisplay this help and exit"
-	echo -e "  \t-p\tdisplay progress meter if recovering"
+	echo -e "  \t-p\tdisplay progress meter if recovering (no shutdown)"
 }
 
 PROGRESS_METER=0
@@ -56,14 +56,14 @@ if mdadm --detail /dev/md0 | grep -q ", recovering $"; then
 		echo -e "\nERROR: Recovery finished. You can try '$0' again without -p."
 		exit 1
 	else
-		echo -e "ERROR: RAID is recovering. Can't start rotation. Try again later."
+		echo -e "ERROR: RAID is recovering. Check progress with 'mdstat'. NOT safe to rotate disks."
 		exit 1
 	fi
 elif mdadm --detail /dev/md0 2>&1 | grep -q "degraded" ; then
-	echo "ERROR: RAID is degraded (and not recovering). Can't start rotation."
+	echo "ERROR: RAID is degraded (and probably not recovering). NOT safe to rotate disks."
 	exit 1
 fi
-echo "RAID not degraded and not recovering. Shutting down for rotation."
+echo "RAID not degraded and not recovering. SAFE to rotate disks. Shutting down ..."
 sync;sync
 sleep 1;
 shutdown -h now

--- a/RAID/rotation_shutdown
+++ b/RAID/rotation_shutdown
@@ -22,14 +22,19 @@
 set -e
 
 usage() {
-	echo "Usage: $0 [-h][-p]"
+	echo "Usage: $0 [-F][-h][-p]"
+	echo -e "  \t-F\toverride the FS running preventing shutdown"
 	echo -e "  \t-h\tdisplay this help and exit"
 	echo -e "  \t-p\tdisplay progress meter if recovering (no shutdown)"
 }
 
 PROGRESS_METER=0
-while getopts "hp" arg; do
+OVERRIDE_FS=0
+while getopts "Fhp" arg; do
 	case $arg in
+		F)
+			OVERRIDE_FS=1
+			;;
 		p)
 			PROGRESS_METER=1
 			;;
@@ -69,6 +74,21 @@ if [ "$PROGRESS_METER" -ne 0 ]; then
 	echo "RAID not degraded and not recovering."
 	echo "You can try '$0' again without '-p'."
 	exit 0
+fi
+
+if test -f /usr2/fs/bin/lognm ; then
+	if [ "$(/usr2/fs/bin/lognm 2>/dev/null)" ] ; then
+		if [ "$OVERRIDE_FS" -ne 0 ]; then
+			echo "The FS running, but -F was used to force a shutdown."
+		else
+			echo "ERROR: The FS is running; won't shutdown. Override with -F (not recommended)."
+			exit 1
+		fi
+	else
+		echo "The FS is not running. Shutting down is not prevented."
+	fi
+else
+	echo "The FS does not appear to be installed. Shutting down is not prevented."
 fi
 
 echo "RAID not degraded and not recovering. SAFE to rotate disks. Shutting down ..."

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -26,7 +26,7 @@
 :toclevels: 3
 :toc:
 Dave Horsley and Ed Himwich
-Version 0.0.4 - August 2022
+Version 0.0.5 - August 2022
 
 == Introduction
 
@@ -597,14 +597,18 @@ run _visudo_ then add at end:
     %programmers    ALL=(prog) NOPASSWD: ALL
     %programmers    ALL=(oper) NOPASSWD: ALL
 
-To allow _operators_ to use _refresh_secondary_, _shutdown_, and _reboot_, add (respectively):
+To allow _operators_ to use _rotation_shutdown_, _refresh_secondary_,
+_shutdown_, and _reboot_, add (respectively):
 
+   %operators      ALL=(ALL) /usr/local/sbin/rotation_shutdown
    %operators      ALL=(ALL) /usr/local/sbin/refresh_secondary
    %operators      ALL=(ALL) /sbin/shutdown
    %operators      ALL=(ALL) /sbin/reboot
 
-To use these commands the _operators_ will need to enter (respectively) from their AUID accounts:
+To use these commands the _operators_ will need to enter
+(respectively) from their AUID accounts:
 
+   sudo rotation_shutdown
    sudo refresh_secondary
    sudo shutdown
    sudo reboot
@@ -615,7 +619,7 @@ If the  user can elevate to _root_, also add:
 
     dhorsley       ALL=(root) ALL
 
-Create the groups if they don't exist:
+If they don't already exist, create the needed groups:
 
     addgroup operators
     addgroup programmers

--- a/installation.adoc
+++ b/installation.adoc
@@ -22,7 +22,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.21 - August 2022
+Version 0.0.22 - August 2022
 
 :sectnums:
 :experimental:
@@ -817,15 +817,27 @@ You can install some useful tools for working with the RAID, if you're actually 
    ~/fsl11/RAID/install_tools
 
 The rest of this document assumes the first three of these tools have
-been installed.  The five tools are:
+been installed. The six tools are:
 
-   * _mdstat_ allows all users to check on the RAID status
-   * _refresh_secondary_ allows _root_ to refresh a secondary disk that is from the same RAID and has been booted on its own
-   * _blank_secondary_ allows _root_ to initialize a secondary disk, must be used with extreme care
-   * _drop_primary_ allows _root_ deliberately to drop the primary disk out of the RAID for use as a backup
-   * _recover_raid_ allows _root_ to re-add a disk that fell out of (or was removed from) the RAID back into it
+* _mdstat_ -- for all users -- check on the RAID status
 
-TIP: More information about RAID operation can be found in the <<raid.adoc#,RAID notes for FSL11>> document.
+* _refresh_secondary_ -- for _root_ -- refresh a _secondary_ disk that
+is from the same RAID
+
+* _blank_secondary_ -- for _root_ -- initialize a _secondary_ disk,
+must be used with extreme care
+
+* _rotation_shutdown_ -- for _root_ -- shutdown the system _if_ it is
+safe to rotate disks
+
+* _drop_primary_ -- for _root_ -- deliberately drop the _primary_ disk
+out of the RAID for use as a backup
+
+* _recover_raid_ -- for _root_ -- re-add a disk that fell out of (or
+was removed from) the RAID back into it
+
+TIP: More information about RAID operation can be found in the
+<<raid.adoc#,RAID notes for FSL11>> document.
 
 === Download the Field System
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.2 - August 2022
+Version 0.0.3 - August 2022
 
 :sectnums:
 :experimental:
@@ -52,17 +52,31 @@ and recommended guidelines.
 These practices are fundamental to the operation of the RAID.
 
 . Never mix disks from different computers in one computer.
-. Never split up a RAID pair unless already synced, check with _mdstat_
+
+. Never split up a RAID pair unless already synced, check with
+_mdstat_.
+
++
+
+TIP: For a disk rotation, use _rotation_shudown_, which will only
+shutdown the system if the RAID is synced.
  
-A RAID pair (kept together and in order) can be removed or moved
-between computers if need be. A disk rotation (or initializing a new
-    disk)  is probably the only reason to split a pair.
++
 
 NOTE: When booting a disk from a RAID by itself, you may see
-~20 of the `volume group
-not found` error messages, then the machine will boot. These error
-messages  only appear like this the first time a disk
-from the RAID is booted without its partner.
+~20 `volume group not found` error messages, then the machine will
+boot. These error messages only appear like this the first time a disk
+from a RAID is booted without its partner.
+
++
+
+A RAID pair (kept together and in order) can be removed/reinserted or
+moved between computers if need be. A disk rotation (or initializing a
+new disk) is the only routine reason to split a pair.
+
+. Set your BIOS to allow hot swapping of disks for both the _primary_
+and _secondary_ controllers. This is necessary to use the RAID
+procedures described in this document.
 
 === Recommended practices
 
@@ -73,7 +87,7 @@ These recommendations are intended to provide consistent procedures and make it 
 . Label the slots as _primary_ and _secondary_ as appropriate.
 . Always boot for a refresh/blank with the _primary_ slot turned on and the _secondary_ slot turned off: so it is clear which is the active disk
 . Label the disks (so visible when in use) with the system name and number them 1, 2, and 3, ...
-. Label the disks (so visible when in use) with their serial numbers, either from _mdstat_ when only one disk inserted or by examining the disk
+. Label the disks (so visible when in use) with their serial numbers, determined either from _mdstat_ when only one disk inserted or by examining the disk
 . For reference, place the disk serial numbers in a file with their corresponding numbers, e.g.:
 
 +
@@ -90,11 +104,7 @@ These recommendations are intended to provide consistent procedures and make it 
 . If you have a spare computer (and/or additional systems), keep the disks in the same sequence on all the computers
 . Do not turn a disk off while the system is running. The only time a key switch state should be changed while the system is running is to add a disk for a blank or refresh operation.
 
-. Set your  BIOS to allow hot swapping of disks for both the _primary_
-and _secondary_ controllers. This is necessary to use the RAID procedures
-described in this document.
-
-== Disk Rotation
+== Disk rotation
 
 This section describes the disk rotation procedure. It is used to make
 periodic updates of the shelf disk.
@@ -103,14 +113,23 @@ NOTE: Your BIOS must be set to allow hot swapping of disks,
 particularly for the _secondary_ controller (it should also be set for
 the _primary_ controller).
 
-TIP: If you do not have access to the _root_ account, you may
-have _sudo_ access to the privileged commands. If so, you will need
-to run the `shutdown -h now` and _refresh_secondary_ commands with
-_sudo_.  This is true for other privileged commands used elsewhere in
-this document.
+TIP: If you do not have access to the _root_ account, you may have
+_sudo_ access to privileged commands. If so, you may be able to run
+_rotation_shutdown_ and _refresh_secondary_ commands with _sudo_,
+e.g., `*sudo{nbsp}rotation_shutdown*`. This also applies to other
+privileged commands used in this document.
 
-. Wait until the RAID is not recovering, check with _mdstat_
-. Shutdown the system, e.g., `shutdown -h now`
+. Shut the system down with the _rotation_shutdown_ command.
+
++
+
+This command will check the status of the RAID and proceed to shutting
+down _only_ if it is safe to perform a disk rotation. If a conflict is
+detected, it will be reported. If the RAID is recovering, you will
+need to wait until the recovery is finished before shutting down. If
+it is degraded, seek expert advice. If the FS is running, you should
+terminate it before using this command.
+
 . Take the disk from _primary_ slot, put it on the _shelf_
 +
 
@@ -141,8 +160,21 @@ Seek expert advice for this, but the basic plan is given below:
 NOTE: Your BIOS must be set to allow hot swapping of disks
 for both the _primary_ and _secondary_ controllers.
 
-. If a rotation hasn't just been completed, perform one (as an extra backup)
-. Before proceeding verify that there is no recovery in progress, check with _mdstat_
+. If a rotation hasn't just been completed, perform one (as an extra
+backup) according to <<Disk rotation>> above.
+
+. Before proceeding verify that there is no recovery in progress,
+check with _mdstat_.
+
++
+
+TIP: You can combine this step and the next one by using the
+_rotation_shutdown_ command, which will shut the system down only of
+the RAID is ready for a disk rotation. The output of that command is
+phrased for doing a disk rotation. For the current case, you will need
+to interpret the output for whether the RAID is ready to be split for
+use in testing.
+
 . Shutdown the system, e.g., `shutdown -h now`
 . Key-off the _primary_ slot
 . Reboot (_primary_ keyed-off, _secondary_ keyed-on)
@@ -244,6 +276,15 @@ used for operations, if need be. In that case, the rest of this
 procedure can be completed when time allows.
 
 . Wait until the RAID is not recovering, check with _mdstat_
+
++
+
+TIP: You can combine this step and the next one by using the
+_rotation_shutdown_ command, which will shut the system down only of
+the RAID is ready for a disk rotation. The output of that command is
+phrased for doing a disk rotation. For the current case, you are
+essentially doing a disk rotation.
+
 . Shutdown the system, e.g., `shutdown -h now`
 . Take the disk from _primary_ slot, put it on the _shelf_
 . Move the disk from the _secondary_ slot to the _primary_ slot, keyed-on
@@ -290,6 +331,15 @@ additional disk>> section of the FSL11 Installation document.
 This case corresponds to not having a good shelf disk.
 
 . Wait until the RAID is not recovering, check with _mdstat_
+
++
+
+TIP: You can combine this step and the next one by using the
+_rotation_shutdown_ command, which will shut the system down only of
+the RAID is ready for a disk rotation. The output of that command is
+phrased for doing a disk rotation. For the current case, you are
+essentially doing a disk rotation.
+
 . Shutdown the system, e.g., `shutdown -h now`
 
 If the disks are in cyclical order (i.e., primary, secondary are
@@ -386,6 +436,24 @@ state of the RAID, including any anomalies.
 The script also lists various useful details for all block devices (such
 as disks) that are currently connected, including their model and serial
 numbers where applicable.
+
+=== rotation_shutdown
+
+This script can be used to shut the system down if the RAID is in a
+state that allows a disk rotation to be performed. For a shutdown to
+occur, the RAID must not be recovering and not be degraded. Otherwise,
+an appropriate error message is printed. If the RAID is recovering,
+you will need to wait until the recovery is finished before shutting
+down. If it is degraded, seek expert advice.
+
+The script will also check to see if the FS is active and will not
+shutdown the system if it is. To override this, the `-F` option can be
+used, but is not recommended. It is better to terminate the FS
+instead.
+
+The script includes a `-p` option to display a progress meter for a
+recovery if one is active. Whether there is a recovery or not, there
+will not be a shutdown if `-p` is used.
 
 === refresh_secondary
 


### PR DESCRIPTION
This is a concept for consideration. The basic idea is to have one type-in that will check if it is safe to do a disk rotation and if is, shut the system down so it can be done. It is part of the quest to reduce the chances that an error will be made at a remote location that could lead to a tedious long-distance recovery (once it is figured out what had gone wrong). I know that sometimes I start a rotation and then wonder if the disks were really synced.

I am not sure what the best name for this script would be. This was the best of the options that I had thought of so far. The script may be useful in some situations where a rotation is not going to be done, but maybe those are rare enough that it is okay that name for the most common use doesn't quite fit.