### PR TITLE
Fix grep for EFI from sgdisk output

### DIFF
--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -169,7 +169,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			echo "Detected BIOS boot partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
 			read $ans
-		elif [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'EFI System')" ]; then
+		elif [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'EFI system')" ]; then
 			echo "Detected EFI System partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
 			read $ans

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -169,8 +169,8 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			echo "Detected BIOS boot partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
 			read $ans
-		elif [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'EFI system')" ]; then
-			echo "Detected EFI System partition: /dev/$part"
+		elif [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'EFI [Ss]ystem')" ]; then
+			echo "Detected EFI system partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
 			read $ans
 		elif [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'Linux filesystem')" ]; then

--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -84,7 +84,7 @@ if $(partprobe -ds /dev/sda | grep -q msdos) && [ ! -d /boot/efi ]; then
 	boot="MBR"
 elif [ ! -z "$(sgdisk -i1 /dev/sda | grep 'BIOS boot')" ] && [ ! -d /boot/efi ]; then
 	boot="BIOS";
-elif [ ! -z "$(sgdisk -i1 /dev/sda | grep 'EFI system')" ] && [ -d /boot/efi ]; then
+elif [ ! -z "$(sgdisk -i1 /dev/sda | grep 'EFI [Ss]ystem')" ] && [ -d /boot/efi ]; then
 	boot="EFI";
 else
 	echo "ERROR: Unrecognised boot scheme on \"Primary\" disk /dev/sda"
@@ -142,7 +142,7 @@ fi
 if [ -b $part1 ] && [ ! -z "$(sgdisk -i1 $disk | grep 'GUID code')" ] &&
    (( [ $boot = "MBR" ] && ! $(partprobe -ds $disk | grep -q msdos) ) ||
     ( [ $boot = "BIOS" ] && [ -z "$(sgdisk -i1 $disk | grep 'BIOS boot')" ] ) ||
-    ( [ $boot = "EFI" ] && [ -z "$(sgdisk -i1 $disk | grep 'EFI system')" ] )); then
+    ( [ $boot = "EFI" ] && [ -z "$(sgdisk -i1 $disk | grep 'EFI [Ss]ystem')" ] )); then
 	echo "ERROR: boot scheme on \"Secondary\" disk $disk does not match \"Primary\" disk /dev/sda"
 	echo "(You should use blank_secondary to reset the second disk)"
 	exit 1

--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -142,7 +142,7 @@ fi
 if [ -b $part1 ] && [ ! -z "$(sgdisk -i1 $disk | grep 'GUID code')" ] &&
    (( [ $boot = "MBR" ] && ! $(partprobe -ds $disk | grep -q msdos) ) ||
     ( [ $boot = "BIOS" ] && [ -z "$(sgdisk -i1 $disk | grep 'BIOS boot')" ] ) ||
-    ( [ $boot = "EFI" ] && [ -z "$(sgdisk -i1 $disk | grep 'EFI System')" ] )); then
+    ( [ $boot = "EFI" ] && [ -z "$(sgdisk -i1 $disk | grep 'EFI system')" ] )); then
 	echo "ERROR: boot scheme on \"Secondary\" disk $disk does not match \"Primary\" disk /dev/sda"
 	echo "(You should use blank_secondary to reset the second disk)"
 	exit 1


### PR DESCRIPTION
An instance of this had been fixed in _refresh_secondary_ before, but in my haste I hadn't looked systematically for more. I am not sure why the second one in _refresh_secondary_ hadn't been hit before, but I haven't tried to fully unravel the logic yet. Perhaps some one more familiar will see it right away. I hit it trying to refresh a disk that was newer than the primary. The script detected that nicely once this fix had been applied.

Both of these changes have been tested. Perhaps the string in all _three_ instances should be `EFI [Ss]ystem', but the changes here work for FSL11 (they won't for FSL10).