### PR TITLE
One disk install

### DIFF
--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -26,7 +26,7 @@
 :toclevels: 3
 :toc:
 Dave Horsley and Ed Himwich
-Version 0.0.7 - August 2022
+Version 0.0.8 - October 2022
 
 == Introduction
 
@@ -802,17 +802,24 @@ instead:
 
 To set the correct default desktop (it is remembered per user):
 
+ cat > /var/lib/AccountsService/users/dehorsley <<EOF
+ [User]
+ Language=
+ XSession=default
+ Icon=/usr2/dehorsleyley/.face
+ SystemAccount=false
+ EOF
+
++
+
+Alternatively, if you have access to the console:
+
 .. Press kbd:[Ctrl+Alt+F1] to get to the GUI login.
 .. Enter `*dhorsley*` as the `Username`.
 .. Select the "`gear`" icon in the lower right-hand corner.
 .. Select `System X11 Default`.
 .. Complete logging in with the password.
 .. Logout with `exit`.
-
-+
-
-#TODO: Eliminate the need for these steps by implementing a proper
-fix, possibly in _fsadapt_.#
 
 === Setting hostname alias
 

--- a/installation.adoc
+++ b/installation.adoc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020-2021 NVI, Inc.
 //
 // This file is part of the FSL10 Linux distribution.
@@ -22,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.25 - September 2022
+Version 0.0.26 - October 2022
 
 :sectnums:
 :experimental:
@@ -175,19 +174,24 @@ use of the UEFI Shell, which may eliminate this situation.
 
 == First Stage Installation
 
-WARNING: This guide assumes that you have two disks installed in the machine
-in order to set them up as a RAID pair. For the RAID to work seamlessly with a
-third disk later, you must make sure that the smallest disk of the three
-disks available is used as the first of this initial RAID pair. Use of a
-single disk (for a test install etc.) is also annotated below.
+This guide assumes that you have only one disk installed in the
+machine initially even if you intend to use a RAID configuration. Use
+of a single disk (for a test install etc.) is also annotated below.
 
-TIP: Installing to a single disk initially is recommended and has some
-advantages. It is faster and you can control when the syncing for the
-second disk occurs, such as when you leave for the evening. The setup
-of additional disks is covered in the <<Post Install>> section (which
-references the <<raid.adoc#,RAID notes for FSL11>> document). As
-mentioned in the warning above, you should start with the smallest
-disk.
+NOTE: The single dish install approach is used because it is faster
+than a dual disk install. It also allows you to control when the
+syncing for the second disk occurs, such as when you leave for the
+evening. The setup of a second and third disk is covered in the
+<<Setup additional disks>> subsection below.
+
+. Install your smallest disk in the _primary_ slot (the one connected
+to the lowest numbered SATA controller, usually `0`.
+
++
+
+CAUTION: For a RAID to work seamlessly with other disks later,
+you must make sure that the smallest disk of the ones available is
+used for the installation.
 
 === Boot from the installation medium
 
@@ -280,10 +284,6 @@ kbd:[Enter].
 Unless you are using DHCP (which is not advisable) you will be
 prompted to:
 
-NOTE: If you are only using the installer to initialize new disks, you
-may want to use `Go Back` and directly select `Detect disks` from the
-main menu to skip forward to <<Setup partitions>> below.
-
 . Type in the required static IP address in the form `_xxx.xxx.xxx.xxx_`
 (where each `_xxx_` is any integer from 0 - 255 inclusive) and press
 kbd:[Enter].
@@ -320,14 +320,12 @@ The installer now tries to set the time using NTP
 If this is not possible at your site due to your firewall etc., you may need
 to press kbd:[Enter] to cancel this process.
 
-=== Setup partitions 
+=== Partition the disk
 
 NOTE: If you are using UEFI and the disk was previously used for BIOS, you may need
 to confirm forcing UEFI installation.
 
-When prompted, select `Manual`
-
-==== Setup the first disk
+. When prompted for a partitioning method, select `Manual`
 
 . If needed, create a new partition table by:
 
@@ -386,10 +384,6 @@ it is possible to avoid using the software RAID layer entirely. Simply select `U
 for this partition instead and skip ahead to <<Setup Logical Volume Manager (LVM)>> below.
 However, please note that a single disk setup is not recommended for any _operational_ system.
 
-==== Setup the second disk
-
-Repeat the process for the second disk, if present.
-
 ==== Setup RAID
 
 . Select `Configure software RAID`. Then select `Yes` to write the
@@ -398,10 +392,9 @@ Repeat the process for the second disk, if present.
 . Select `Create MD device`, choose `RAID1` and enter `*2*` as number
 of devices and `*0*` as number of spares.
 
-. Select the RAID partitions we just created by pressing kbd:[Space]
--- these should be _sda2_ and _sdb2_, if you have just one disk, just
-pick _sda2_ -- then press kbd:[Enter] to continue. Select `yes` if
-prompted to write changes to disk.
+. Select the RAID partition we just created by pressing kbd:[Space].
+This should be _sda2_. Then press kbd:[Enter] to continue. Select
+`yes` if prompted to write changes to disk.
 
 . Select `Finish`.
 
@@ -608,21 +601,7 @@ NOTE: If you do keep this account, you will not be able to run the FS from
 it unless you add this account into the additional hardware access groups
 such as is done for _oper_ and _prog_ by _fsadapt_.
 
-=== Install GRUB to the second disk (if available)
 
-* If you installed with UEFI boot, run the command
-+
-    cp /dev/sda1 /dev/sdb1
-
-* If you installed with BIOS boot, install GRUB to the Master Boot Record by
-running: `*dpkg-reconfigure -plow grub-pc*` and after pressing
-kbd:[Enter] twice to accept the kernel command line extra arguments
-and default command line arguments, use the arrow keys and
-kbd:[Space] to select both _/dev/sda_ and _/dev/sdb_ (but not
-    _/dev/md0_) and press kbd:[Enter] to finalise the reconfiguration.
-(You should then see `Installation finished. No error reported` appear
- twice in the progress messages as GRUB is re-installed to both
- drives.)
 
 === Setup HTTP Proxy for APT (Optional)
 Should you wish to make APT use an HTTP proxy for downloads,
@@ -917,42 +896,31 @@ then
 
 to confirm that everything compiled correctly (no news is good news).
 
-=== Wait for the RAID1 disk mirroring to set up
+=== Reboot the new system
 
-If you installed the RAID (and RAID tools) check its progress with:
+Remove any DVD from the machine and to restart the machine using
+_reboot_ as _root_ or kbd:[Ctrl+Alt+Del] whilst watching that
+everything starts up smoothly.
 
-   mdstat
+== Fourth stage Installation
 
-until the array no-longer shows a recovery in progress.
+=== Setup additional disks
 
-The final steps are to remove any DVD from the machine and to restart the machine
-using _reboot_ as _root_ or kbd:[Ctrl+Alt+Del] whilst watching that everything
-starts up smoothly.
+If your are using a RAID, follow the steps in this subsection to setup
+the second and third disks.
 
-Your new FS machine should now be ready to be customised to your requirements
-by tailoring the control files in _/usr2/control_ and adding suitable station
-specific software to _/usr2/st_.  See the files in the _/usr2/fs/misc_ directory
-for more information.
-
-
-== Post Install
-
-All commands (except checking the RAID status) in this section need to be run as _root_.
-
-=== Setup additional disk
-
-NOTE: An additional disk should be at least as large as the smallest
-disk already in use in the RAID.
+NOTE: Additional disks should be at least as large as the disk already
+in use.
 
 NOTE: You will need to have hot-swapping enabled in your motherboard's
 setup menu, at least for the controller for the _secondary_ disk (it
 should also be enabled for the _primary_).
 
-NOTE: This subsection assumes you have followed the directions in the
-<<Install tools for RAID (Optional)>> section above.
+NOTE: This subsection assumes you have installed the RAID tools
+according to the <<Install tools for RAID (optional)>> subsection
+above.
 
-. If you have a second disk (_secondary_) in the RAID, either because
-you installed with it or because you have subsequently set it up:
+. If you have a second disk (_secondary_) in the RAID:
 
 .. Shut the system down with the _rotation_shutdown_ command.
 
@@ -968,64 +936,83 @@ need to wait until the recovery is finished before shutting down, you
 can check the progress with the _mdstat_ command; and (iii) if the
 RAID is `degraded`, seek expert advice.
 
-.. Remove the _secondary_ disk and place it on the shelf.
+.. Remove the disk in the _primary_ slot and place it on the shelf,
+labelled appropriately as the _shelf_ disk for this system with the
+date.
 
-. Proceed to the next step, <<Initialize new disk>>.
+.. Move the disk in the _secondary_ slot to the _primary_ slot.
 
-==== Initialize new disk
+. Initialize the new disk
+
++
 
 IMPORTANT: Do not initialize a disk unless you are sure there is no
 data on it that you need to preserve.
 
++
+
 For the first time use of an additional disk with a new install, the
-disk should be initialized to make sure it has no already existing
-structure. This should be done even if the disk has been used in a
-different FS computer or a previous install on this computer.
+disk should be initialized to make sure it has no existing structure.
+This should be done even if the disk has been used in a different FS
+computer or a previous install on this computer.
 
-Follow these steps:
-
-. Boot with just the _primary_ disk installed.
+.. Boot with just the _primary_ disk installed.
 
 +
 
 TIP: If your system is already running with no second disk
-(_secondary_) installed, you can skip booting.
+(_secondary_) installed, you can skip rebooting.
 
-. Use the script:
+.. Use the script:
 
    blank_secondary
 
 +
 
++
+
 The script will wait for the new disk to be turned on. Insert a new
-disk in the _secondary_ slot. Turn the key to turn the disk on. There
-will be a prompt asking if wish to proceed. If it is a new disk or you
-are sure it safe to erase this disk, answer `*y*`. If you are unsure
-about this or otherwise need to abort answer `*n*`.
+disk in the _secondary_ slot. The secondary slot is the one connected
+to second lowest numbered SATA controller, usually `1`. Turn the key
+to turn the disk on. There will be a prompt asking if wish to proceed.
+If it is a new disk or you are sure it safe to erase this disk, answer
+`*y*`. If you are unsure about this or otherwise need to abort, answer
+`*n*`.
 
-==== Refresh secondary disk
+. Refresh the now blank _secondary_ disk
 
-CAUTION: As written, this subsection is only to be used immediately
-after the previous subsection, <<Initialize new disk>>.
++
 
 Run the script:
 
     refresh_secondary
-  
+
++
+
 Once you reach the message that you can check on the recovery with
 _mdstat_ , you can resume using the computer as usual. You can safely
 reboot at this point, if it is needed; just don't remove either disk
 until the recovery is finished.
 
++
+
 You can check the progress of the recovery with:
 
     mdstat
 
-When the recovery is complete, you can repeat the process of the
-entire subsection, <<Setup additional disk>>, if you have a third disk
-that needs to be setup.
++
 
-=== Consider additional customizations
+When the recovery is complete, you can repeat the process of this
+entire subsection, <<Setup additional disks>>, to initialize another
+disk.
+
+== Post install
+
+Your new FS machine should now be ready to be customised to your
+requirements by tailoring the control files in _/usr2/control_ and
+adding suitable station specific software to _/usr2/st_. See the files
+in the _/usr2/fs/st.default/st-0.0.0_ directory for starter versions
+of the latter.
 
 Please refer to the appendix <<Additional Setup Items>> for
 customizations that your system may need or that you may find useful.

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.28 - October 2022
+Version 0.0.29 - October 2022
 
 :sectnums:
 :experimental:
@@ -161,8 +161,9 @@ alternatives when the instructions differ.
 Decide which boot mode you want to use and select it through the motherboard
 _setup_ menu (typically by pressing kbd:[DEL] during POST).
 
-Also make sure that the motherboard time is set to the current Universal time, i.e.,
-UTC, and the motherboard can boot from the installation media.
+Make sure that the motherboard time is set to the current Coordinated
+Universal Time, i.e., UTC, and the motherboard can boot from the
+installation media.
 
 While you are in the motherboard menu, make sure that hot-swapping is
 enabled for the controllers of both the _primary_ and _secondary_
@@ -176,7 +177,7 @@ motherboard's _setup_ utility to restore booting from the hard disks.
 The `Boot` menu may be where this is set. You may able able to disable
 use of the UEFI Shell, which may eliminate this situation.
 
-== First Stage Installation
+== First stage installation
 
 This guide assumes that you have only one disk installed in the
 machine initially even if you intend to use a RAID configuration. Use
@@ -199,16 +200,20 @@ used for the installation.
 
 === Boot from the installation medium
 
-Connect an active network cable to your lowest numbered interface
+. Connect an active network cable to your lowest numbered interface
 (only). Usually it is on the left if there are two.
 
-Insert/plug-in your installation media and reboot.
+. Insert/plug-in your installation media and reboot.
+
++
 
 To boot from the installation media you may need to bring up your
 motherboard's _setup_ utility, which is typically accessed by pressing
 kbd:[F11] or kbd:[F12]. From there you may need to access a menu such
 as `Save{nbsp}&{nbsp}Exit` (or `Boot`), to select overriding to boot
 with the installation media.
+
++
 
 TIP: If the system was most recently booted from a hard disk, you may
 need to boot one time with no hard disk installed for the
@@ -324,9 +329,9 @@ password twice as prompted.
 
 === Get network time
 
-The installer now tries to set the time using NTP
-If this is not possible at your site due to your firewall etc., you may need
-to press kbd:[Enter] to cancel this process.
+The installer now tries to set the time using NTP. If this is not
+possible at your site due to your firewall etc., you may need to press
+kbd:[Enter] to cancel this process.
 
 === Partition the disk
 
@@ -416,7 +421,8 @@ This should be _sda2_. Then press kbd:[Enter] to continue. Select
 
 . Select `Finish`.
 
-. Back in partitioning, select the space _under_ `RAID1 device #0` and press kbd:[Enter]
+. Back in partitioning, select the (unassigned) partition `#1` _under_
+`RAID1 device #0` and press kbd:[Enter]
 
 . Select `Use as`, then select `physical volume for LVM`, then `Done
 setting up the partition`
@@ -473,8 +479,9 @@ usually only takes a few minutes.
 === Configure the package manager
 
 If you start from a _netinst_ CD image, the installer now assumes you
-will install only from the network, and jumps straight to the "`Choose your `Debian
-archive mirror country``" part of the dialogue as detailed below.
+will install only from the network, and jumps straight to the
+<<archive,`Choose your Debian archive mirror country`>> part of the
+dialogue as detailed below.
 
 If you are using DVD installer you will be prompted to scan additional DVDs.
 Scanning the additional DVDs (and obtaining copies of them in the
@@ -502,9 +509,10 @@ list may be suppressed.
 Select `Yes` and press  kbd:[Enter]  to use a network mirror (unless you
 have inadequate Internet access - but then you must scan all DVDs.)
 
-Choose your `Debian archive mirror country` from the list if available
-and press kbd:[Enter]. (If your country is not available choose the
-country nearest to you in a network connectivity sense.)
+<<archive,`Choose your Debian archive mirror country`>>[[archive]]:
+Select from the list if available and press kbd:[Enter]. (If your
+country is not available choose the country nearest to you in a
+network connectivity sense.)
 
 Select the fastest Debian mirror from those available.
 
@@ -552,13 +560,19 @@ When prompted, press kbd:[Enter] to install to the master boot record.
 This step should be executed when the installation stops for input in
 the next step, <<Remove installation media>>.
 
+#TODO: Is there a way to test for this without having to see if there
+is a problem after the reboot?#
+
 IMPORTANT: `Wayland` is enabled by default. If your CPU does not
-include a GPU, you will probably need to disable it. If you don't, the
-console may be nearly impossible to work with after rebooting. On the
-other hand, systems with other graphics solutions may be very
-difficult to work with if `Wayland` is disabled. You may need to try
-both approaches to see which works best. If you try one that doesn't
-work well, you may need to reinstall from scratch to try the other.
+include a GPU and you do not have an add-graphics card (in which case
+you are using the motherboard graphics), you will probably need to
+disable it. If you don't, the console may be nearly impossible to work
+with after rebooting. On the other hand, systems with those graphics
+solutions may be very difficult to work with if `Wayland` is disabled.
+You may need to try both approaches to see which works best. If you
+try one that doesn't work well, you may need to reinstall from scratch
+to try the other. Whether your choice works or not should be evident
+when you start the <<Second stage installation>> step below.
 
 To disable `Wayland`:
 
@@ -591,9 +605,9 @@ floppy i.e., anything other than the hard drive, in the BIOS just in
 case someone leaves something nasty in the machine's removable drives
 by mistake.
 
-== Second Stage Installation
+== Second stage installation
 
-You can now boot to your new OS.
+You should now have booted to your new OS.
 
 === Login as root 
 
@@ -610,8 +624,8 @@ earlier.
 
 === Remove the dummy Desktop User (optional)
 
-Unless you want another account that that is set up to use the default
-desktop environment, delete _desktop_ with:
+Unless you want an account that is set up to use the default desktop
+environment, delete the _desktop_ user with:
 
    deluser --remove-home desktop
 
@@ -620,8 +634,8 @@ it unless you add this account into the additional hardware access groups
 such as is done for _oper_ and _prog_ by _fsadapt_.
 
 
+=== Setup HTTP proxy for APT (optional)
 
-=== Setup HTTP Proxy for APT (Optional)
 Should you wish to make APT use an HTTP proxy for downloads,
 create the new file _/etc/apt/apt.conf.d/00proxies_ using _vi_ containing:
 
@@ -728,7 +742,7 @@ So that the update mechanism will work correctly, run
    apt-get clean
 
 
-== Third Stage Installation 
+== Third stage installation
 
 === fsadapt
 
@@ -740,7 +754,8 @@ In the _/root/fsl11_ directory, start _fsadapt_ with
 
 Using the arrow keys and kbd:[Space] make your selections and press kbd:[Enter].
 
-*  If you are not using a GPIB board or USB dongle, you can deselect the GPIB option.
+* If you are not using a GPIB board or USB dongle, you can deselect
+the GPIB option.
 
 * If you are using the RAID configuration, you must _not_ deselect
 the `mdinc` option.
@@ -760,7 +775,7 @@ NOTE: The `updates` option relies on email to _root_ being re-directed to some
       test it as well.  The installer sets it up to go the _desktop_ account
       by default which would definitely be a problem if you have removed that!
 
-==== GPIB driver configuration (Optional)
+==== GPIB driver configuration (optional)
 
 On the `/etc/gpib.conf` screen, use the up/down arrow keys to select the
 required GPIB controller and press kbd:[Enter] on `OK` to continue.
@@ -791,7 +806,7 @@ up and finish with _fsadapt_.
 Note that the _fsadapt_ script can be re-run at a later date should you need to
 change the adaptations.
 
-=== Set Passwords
+=== Set passwords
 
 Set passwords for the _oper_ and _prog_ accounts with:
 
@@ -800,7 +815,7 @@ Set passwords for the _oper_ and _prog_ accounts with:
 
 entering the passwords twice as prompted.
 
-=== Install tools for RAID (Optional)
+=== Install tools for RAID (optional)
 
 You can install some useful tools for working with the RAID, if you're actually using it, with:
 
@@ -1005,14 +1020,14 @@ disk.
 
 == Post install
 
-Your new FS machine should now be ready to be customised to your
-requirements by tailoring the control files in _/usr2/control_ and
-adding suitable station specific software to _/usr2/st_. See the files
-in the _/usr2/fs/st.default/st-0.0.0_ directory for starter versions
-of the latter.
+The FS on your newly installed system should now be ready to be
+customized for your site's requirements by tailoring the control files
+in _/usr2/control_ and adding suitable station specific software to
+_/usr2/st_. See the files in the _/usr2/fs/st.default/st-0.0.0_
+directory for starter versions of the latter.
 
-Please refer to the appendix <<Additional Setup Items>> for
-customizations that your system may need or that you may find useful.
+Please refer to the appendix <<Additional Setup Items>> for OS
+customizations that you may find useful.
 
 [appendix]
 :sectnumlevels: 4
@@ -1036,7 +1051,7 @@ the <<cis-setup.adoc#,CIS hardening FSL11>> document.
 If you don't want the complete CIS hardening, which creates some
 inconveniences and is only required in certain environments, you may
 still be interested in applying a subset of the remediations. You can
-pick and choose those from the <<cis-setup.adoc#,CIS hardening FSL11>>
+pick and choose those from the <<cis-setup.adoc#,CIS Hardening FSL11>>
 document and its script.
 
 A useful minimum set of features to apply would be to install _ufw_
@@ -1240,7 +1255,7 @@ Execute this command:
 apt-get purge modemmanger
 ....
 
-=== Remove Anacron package
+=== Remove anacron package
 
 If you enabled the weekly update job in _fsadapt_ (it is strongly
 recommended), we recommend that you also remove the _anacron_ package
@@ -1703,7 +1718,7 @@ instructions, please see the
 :sectnumlevels: 3
 [appendix]
 
-== Managing Security Updates
+== Managing security updates
 
 It is strongly recommended that you use the weekly _cron_ update
 download (the "`weekly _cron_ job`") as configured according to the
@@ -1719,7 +1734,7 @@ NOTE: An optional method for identifying available  updates without using
 the weekly _cron_ job is described below in the section
 <<Manually checking for updates>>.
 
-=== Installing updates (Upgrading)
+=== Installing updates (upgrading)
 
 TIP: It is recommended that a disk rotation be performed before any
 update is installed. This will make recovery much easier if a problem with the
@@ -1916,7 +1931,7 @@ If there is no output, there are no updates to install.
 
 If there is output, there are updates to install. You can install them
 by following the installation procedure in subsection
-<<Installing updates (Upgrading)>> above, except you will use the
+<<Installing updates (upgrading)>> above, except you will use the
 instructions from the output of the script above instead of from the
 weekly _cron_ job (the outputs should be equivalent for the same set
 of updates).  Additionally, please read the following *NOTE*.

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.26 - October 2022
+Version 0.0.27 - October 2022
 
 :sectnums:
 :experimental:
@@ -88,10 +88,14 @@ at: https://nvi-inc.github.io/fs/misc/font_conventions.html.
 
 == Choosing architecture and creating installation media
 
-As of Field System version _10.0_, both _i386_ and _amd64_ architectures
-are supported natively. The _amd64_ architecture is preferred and
-should be used if possible (it should be unless the processor is very
-    old, from about 2010 or older).  However, some work may be
+#TODO: edit in correct version number below#
+
+FSL11 can be configured for either the _i386_ or _amd64_
+architectures. With FSL11 it is necessary to use Field System version
+#_10.1.1_# or later. Those FS versions support both architectures
+natively, so either may be used. The _amd64_ architecture is preferred
+and should be used if possible (it should be unless the processor is
+very old, from about 2010 or older). However, some work may be
 required to port your station code from a 32-bit to a 64-bit OS. Some
 automatic tools have been developed for this, and can be provided upon
 request. Usually the _i386_ architecture will work on any processor,
@@ -336,7 +340,10 @@ SATA HARDDISK`, and press kbd:[Enter]
 
 +
 
-NOTE: If some other file system, like `xfs`, or other old setup is
+[NOTE]
+====
+
+If some other file system, like `xfs`, or other old setup is
 displayed, you will need to delete it first. You may be able to do
 this by deleting individual partitions until you have a single `FREE
 SPACE` area. For more complicated layouts, it may be more expedient,
@@ -349,6 +356,13 @@ files in one partition (recommended for new users)`. You may be
 prompted to confirm deleting RAID partitions and/or removing logical
 volume data, which you must do to continue. Then you should be able to
 continue with selecting your disk, as above.
+
+If you have problems later creating the RAID or LVM partitions, then
+other means, such as exotic paths through the partitioner or writing a
+large number (perhaps 10 GB) of zeros at the start of the disk, may be
+necessary.
+
+====
 
 .. The installer may warn: `You have selected an entire device to
 partition…`. If so, select `Yes`
@@ -432,7 +446,7 @@ optional unless you are applying CIS hardening.
 |7 |_/tmp_           | `tmp`      | 50 G
 |8 |_/var_           | `var` *     | 8 G
 |9 |_/var/tmp_       | `vartmp` *  | 8 G
-|10|_/usr2_          | `usr2`     | remaining disk space _less ~50 GB_
+|10|_/usr2_          | `usr2`     | remaining disk space _less ~100 GB_
 |=======================================
 
 . In the LVM configuration window, select `Finish`
@@ -724,6 +738,9 @@ Using the arrow keys and kbd:[Space] make your selections and press kbd:[Enter].
 
 *  If you are not using a GPIB board or USB dongle, you can deselect the GPIB option.
 
+* If you are using the RAID configuration, you must _not_ deselect
+the `mdinc` option.
+
 ==== FS Adaptation: Setup (Window 2)
 
 All of the steps in Window 2 need to be done once (even if you do not
@@ -769,15 +786,6 @@ up and finish with _fsadapt_.
 
 Note that the _fsadapt_ script can be re-run at a later date should you need to
 change the adaptations.
-
-=== Disable suspend
-
-To disable system suspend for console inactivity, execute:
-
- ~/fsl11/disable_suspend
-
-#TODO: Eliminate the need for this script by implementing a proper
-fix, possibly in _fsadapt_.#
 
 === Set Passwords
 
@@ -865,21 +873,6 @@ install default copies of all the FS related directories.
    make install
 
 and enter `*y*` to confirm installation.
-
-=== Set default desktop
-
-To set the correct default desktop (it will be remembered per user):
-
-. Press kbd:[Ctrl+Alt+F1] to get to the GUI login.
-. Select `FS Operator`.
-. Select the "`gear`" icon in the lower right-hand corner.
-. Select `System X11 Default`.
-. Complete logging in with the password.
-. Logout with `exit`.
-. Repeat the above steps for `FS Programmer`.
-
-#TODO: Eliminate the need for these steps by implementing a proper
-fix, possibly in _fsadapt_.#
 
 === Make the FS
 
@@ -1836,6 +1829,22 @@ packages, but it will not install the new packages. While this method can
 be used to install the other updates, it is not recommended since
 there are presumably security patches needed for the kernel and they
 are not being installed in this case.
+
+[TIP]
+====
+
+When the kernel is upgraded, you maybe get messages such as:
+
+ update-initramfs: Generating /boot/initrd.img-5.10.0-16-amd64
+ W: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast
+
+These are usually benign, unless you need that firmware. If not, these
+messages can be silenced for future upgrades by creating an empty
+version of the file. For this example, enter:
+
+ touch /lib/firmware/ast_dp501_fw.bin
+
+====
 
 ==== Updating out-of-tree modules
 

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.27 - October 2022
+Version 0.0.28 - October 2022
 
 :sectnums:
 :experimental:
@@ -276,18 +276,22 @@ then press kbd:[Enter] to continue. It may well be simpler just to use
 the unofficial installer images mentioned above that include all
 available non-free firmware.
 
-=== If you are presented with a dialog asking which interface to use 
+=== Configure the network
 
-Typically only shown if two or more network interfaces are found,
+. If you are presented with a dialog asking which interface to use as
+`primary`
+
++
+
+This is typically only shown if two or more network interfaces are found,
 which might include a virtual FireWire interface in some cases.
 Select the interface you require (usually `eno1`) and press
 kbd:[Enter].
 
-=== Configure the network
-
 Unless you are using DHCP (which is not advisable) you will be
 prompted to:
 
+[start=2]
 . Type in the required static IP address in the form `_xxx.xxx.xxx.xxx_`
 (where each `_xxx_` is any integer from 0 - 255 inclusive) and press
 kbd:[Enter].

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.32 - October 2022
+Version 0.0.33 - October 2022
 
 :sectnums:
 :experimental:
@@ -97,7 +97,7 @@ natively, so either may be used. The _amd64_ architecture is preferred
 and should be used if possible (it should be unless the processor is
 very old, from about 2010 or older). However, some work may be
 required to port your station code from a 32-bit to a 64-bit OS. An
-automatic tool have been developed to help with this, and can be
+automatic tool has been developed to help with this, and can be
 provided upon request. Usually the _i386_ architecture will work on
 any processor, but requires use of the `Legacy` (or `BIOS`) boot mode
 in most cases. The _amd64_ installation media will fail to boot on a
@@ -175,8 +175,8 @@ shell if they fail to find a hard disk that will boot. This might
 happen, for example, if you attempt to boot from a blank disk. If you
 become stuck booting to the UEFI shell, you may need to enter the
 motherboard's _setup_ utility to restore booting from the hard disks.
-The `Boot` menu may be where this is set. You may able to disable use
-of the UEFI Shell, which may eliminate this situation.
+The `Boot` menu may be where this is set. You may be able to disable
+use of the UEFI Shell, which may eliminate this situation.
 
 == First stage installation
 

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.31 - October 2022
+Version 0.0.32 - October 2022
 
 :sectnums:
 :experimental:
@@ -47,8 +47,8 @@ not want to use the software RAID.
 If you are using the RAID configuration, you may wish to review the
 <<raid.adoc#_recommended_practices,Recommended practices>> subsection
 of the <<raid.adoc#,RAID notes for FSL11>> document before installing.
-However, all of the practices listed there can implemented after the
-installation steps below are complete.
+However, all of the practices listed there can be implemented after
+the installation steps below are complete.
 
 TIP: Removable disks should be used with a carrier/receiver system
 that can tolerate a large number of insertions; "`bare`" disks should
@@ -96,12 +96,12 @@ architectures. With FSL11 it is necessary to use Field System version
 natively, so either may be used. The _amd64_ architecture is preferred
 and should be used if possible (it should be unless the processor is
 very old, from about 2010 or older). However, some work may be
-required to port your station code from a 32-bit to a 64-bit OS. Some
-automatic tools have been developed for this, and can be provided upon
-request. Usually the _i386_ architecture will work on any processor,
-but requires use of the `Legacy` (or `BIOS`) boot mode in most cases.
-The _amd64_ installation media will fail to boot on a system that is
-32-bit only.
+required to port your station code from a 32-bit to a 64-bit OS. An
+automatic tool have been developed to help with this, and can be
+provided upon request. Usually the _i386_ architecture will work on
+any processor, but requires use of the `Legacy` (or `BIOS`) boot mode
+in most cases. The _amd64_ installation media will fail to boot on a
+system that is 32-bit only.
 
 To install Debian _11_, you can either use a DVD or USB drive. The latter is
 faster, and also easier if you wish to use UEFI. Directions for creating your
@@ -158,8 +158,9 @@ emulation ("`Legacy`"). UEFI is the preferred approach.  Either mode of
 boot is supported by this installation guide, and you will be given
 alternatives when the instructions differ. 
 
-Decide which boot mode you want to use and select it through the motherboard
-_setup_ menu (typically by pressing kbd:[DEL] during POST).
+Decide which boot mode you want to use and select it through the
+motherboard _setup_ menu (typically by pressing kbd:[Delete] during
+the power-on self test, aka POST).
 
 Make sure that the motherboard time is set to the current Coordinated
 Universal Time, i.e., UTC, and the motherboard can boot from the
@@ -174,14 +175,14 @@ shell if they fail to find a hard disk that will boot. This might
 happen, for example, if you attempt to boot from a blank disk. If you
 become stuck booting to the UEFI shell, you may need to enter the
 motherboard's _setup_ utility to restore booting from the hard disks.
-The `Boot` menu may be where this is set. You may able able to disable
-use of the UEFI Shell, which may eliminate this situation.
+The `Boot` menu may be where this is set. You may able to disable use
+of the UEFI Shell, which may eliminate this situation.
 
 == First stage installation
 
 This guide assumes that you have only one disk installed in the
 machine initially even if you intend to use a RAID configuration. Use
-of a single disk (for a test install etc.) is also annotated below.
+of a single disk (for a test install, etc.) is also annotated below.
 
 NOTE: The single dish install approach is used because it is faster
 than a dual disk install. It also allows you to control when the
@@ -194,9 +195,9 @@ to the lowest numbered SATA controller, usually `0`.
 
 +
 
-CAUTION: For a RAID to work seamlessly with other disks later,
-you must make sure that the smallest disk of the ones available is
-used for the installation.
+CAUTION: For the RAID to work seamlessly with other disks later, you
+must make sure that the smallest disk of the ones available is used
+for the installation.
 
 === Boot from the installation medium
 
@@ -209,9 +210,9 @@ used for the installation.
 
 To boot from the installation media you may need to bring up your
 motherboard's _setup_ utility, which is typically accessed by pressing
-kbd:[F11] or kbd:[F12]. From there you may need to access a menu such
-as `Save{nbsp}&{nbsp}Exit` (or `Boot`), to select overriding to boot
-with the installation media.
+kbd:[Delete] during the POST. From there you may need to access a menu
+such as `Save{nbsp}&{nbsp}Exit` (or `Boot`), to select overriding to
+boot with the installation media.
 
 +
 
@@ -354,11 +355,11 @@ SATA HARDDISK`, and press kbd:[Enter].
 WARNING: Do _not_ select your installation media.
 
 .. The installer may warn: `You have selected an entire device to
-partition…`. If so, select `Yes`.
+partition…`. If so, select `Yes`. If you are prompted to delete RAID
+partitions, select `Yes`.
 
-.. If you are prompted to delete RAID partitions, select `Yes`.
-
-. Select the (one and only entry) `FREE SPACE` under your disk.
+. Select the (one and only entry) `FREE SPACE` under your disk. There
+should be no RAID or LVM partitions shown.
 
 +
 
@@ -367,12 +368,12 @@ partition…`. If so, select `Yes`.
 [NOTE]
 ====
 
-If you have other entries and/or you have RAID or LVM partitions, you
-will need to delete the other entries before proceeding.
+If other entries and/or RAID or LVM partitions are shown, you will
+need to delete them before proceeding.
 
-If you do _not_ have any RAID or LVM partitions shown, a possible
-solution may be to delete individual partitions until you have a
-single entry, `FREE SPACE`.
+If no RAID and/or LVM partitions are shown, a possible solution may be
+to delete individual partitions until you have a single entry, `FREE
+SPACE`.
 
 If that doesn't work or RAID and/or LVM partitions are shown, you may
 be able to use `Guided partitioning` to delete the existing
@@ -388,8 +389,9 @@ selecting your disk, as above.
 If the `Guided partitioning` method above doesn't work or you have
 problems later creating the RAID or LVM partitions, then other means
 will be needed. There may be more complicated paths through the
-partitioner that will work or you may need to overwrite the start of
-the disk with a large number, say 2 GiB (but possibly more), of zeros.
+partitioner that will work or, perhaps easier, you may need to
+overwrite the start of the disk with a large number, say 2 GiB (but
+possibly more, if that doesn't solve the problem), of zeros.
 
 <<zeros,Overwriting with zeros>>[[zeros]]: can be implemented (for 2
 GiB) at this stage in the installer with:
@@ -484,9 +486,10 @@ layout and configure LVM.
 . Select the raid device _md0_ (or _sda2_ if not using RAID)  by pressing kbd:[Space], then press kbd:[Enter]
 to continue
 
-. For each item in the following table run `Create logical volume`, select the
-your volume group and assign the corresponding label. Those marked with `*` are
-optional unless you are applying CIS hardening.
+. For each item in the following table run `Create logical volume`,
+select your volume group and assign the corresponding name. Those
+marked with `*` are optional unless you are applying CIS hardening.
+
 +
 .Logical volumes
 |=======================================
@@ -523,8 +526,8 @@ usually only takes a few minutes.
 
 === Configure the package manager
 
-If you start from a _netinst_ CD image, the installer now assumes you
-will install only from the network, and jumps straight to the
+If you started from a _netinst_ CD image, the installer now assumes
+you will install only from the network, and jumps straight to the
 <<archive,`Choose your Debian archive mirror country`>> part of the
 dialogue as detailed below.
 
@@ -534,8 +537,9 @@ first place) is entirely optional, and is only useful if you don't have a
 reliable network connection to a suitable Debian mirror and hence would
 prefer not to download packages you could get from the DVD.
 
-NOTE: If you do want to use a mirror in future, it is better not to scan any
-DVDs at this stage and to scan them later during Stage 2 using _apt-cdrom_.
+NOTE: If you do want to use a mirror in the future, it is better not
+to scan any DVDs at this stage and to scan them later during Stage 2
+using _apt-cdrom_.
 
 For each additional DVD you wish to scan, insert it in the drive, select
 `Yes` and press  kbd:[Enter]  to perform the scan (which takes a while.)
@@ -609,15 +613,15 @@ the next step, <<Remove installation media>>.
 is a problem after the reboot?#
 
 IMPORTANT: `Wayland` is enabled by default. If your CPU does not
-include a GPU and you do not have an add-graphics card (in which case
-you are using the motherboard graphics), you will probably need to
-disable it. If you don't, the console may be nearly impossible to work
-with after rebooting. On the other hand, systems with those graphics
-solutions may be very difficult to work with if `Wayland` is disabled.
-You may need to try both approaches to see which works best. If you
-try one that doesn't work well, you may need to reinstall from scratch
-to try the other. Whether your choice works or not should be evident
-when you start the <<Second stage installation>> step below.
+include a GPU and you do not have an add-on graphics card (in which
+case you are using the motherboard graphics), you will probably need
+to disable it. If you don't, the console may be nearly impossible to
+work with after rebooting. On the other hand, systems with those
+graphics solutions may be very difficult to work with if `Wayland` is
+disabled. You may need to try both approaches to see which works best.
+If you try one that doesn't work well, you may need to reinstall from
+scratch to try the other. Whether your choice works or not should be
+evident when you start the <<Second stage installation>> step below.
 
 To disable `Wayland`:
 
@@ -815,10 +819,12 @@ two related options on this page (but do not deselect `set_perms` as it
 is always required). Otherwise, simply press kbd:[Enter] with the `OK`
 selected to continue.
 
-NOTE: The `updates` option relies on email to _root_ being re-directed to some
-      mailbox that will be read regularly, so make sure you set that up and
-      test it as well.  The installer sets it up to go the _desktop_ account
-      by default which would definitely be a problem if you have removed that!
+NOTE: The `updates` option relies on email to _root_ being re-directed
+to some mailbox that will be read regularly, so make sure you set that
+up and test it as well (see the <<Configure e-mail>> section in the
+<<Additional Setup Items>> appendix). The installer sets it up to go
+the _desktop_ account by default which would definitely be a problem
+if you have removed that!
 
 ==== GPIB driver configuration (optional)
 
@@ -908,7 +914,9 @@ later.
 [IMPORTANT]
 ====
 
-Although _10.1.0_ is the current release at the time this was written,
+#TODO: edit in correct version number below#
+
+Although #_10.1.0_# is the current release at the time this was written,
 and should suffice for an initial installation, it may well not be the
 most up-to-date release when you are installing. To find more recent
 releases, go to:
@@ -1927,14 +1935,14 @@ are not being installed in this case.
 [TIP]
 ====
 
-When the kernel is upgraded, you maybe get messages such as:
+When the kernel is upgraded, you may get messages such as:
 
  update-initramfs: Generating /boot/initrd.img-5.10.0-16-amd64
  W: Possible missing firmware /lib/firmware/ast_dp501_fw.bin for module ast
 
-These are usually benign, unless you need that firmware. If not, these
-messages can be silenced for future upgrades by creating an empty
-version of the file. For this example, enter:
+These are usually benign, unless you need that firmware. If you don't,
+these messages can be silenced for future upgrades by creating an
+empty version of the file. For this example, enter:
 
  touch /lib/firmware/ast_dp501_fw.bin
 

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.29 - October 2022
+Version 0.0.30 - October 2022
 
 :sectnums:
 :experimental:
@@ -1269,14 +1269,14 @@ apt-get purge anacron
 
 === Configure e-mail
 
-The configuration described here (`Internet site` or `mail
-sent by smarthost` in the _exim4_ configuration, no incoming
-mail, reply-to-filter, and modified user names), provides
-good support of the FS _msg_ and _rdbemsg_ utilities.
+The configuration described here (`Internet site` or `mail sent by
+smarthost` in the _exim4_ configuration, no incoming mail, reply-to
+filter, and modified user names), provides good support for system
+messages and the FS _msg_ and _rdbemsg_ utilities.
 
 . As `root`, enter:
 
-   dpkg-reconfigure exim4-config
+ dpkg-reconfigure exim4-config
 
 +
 
@@ -1290,40 +1290,60 @@ will also need to enable SMTP connections in `Window 4` of _fsadapt_
 connections for it). We recommend that you NOT receive incoming mail
 on this computer.
 
-. If you follow the recommendation not to receive incoming mail and
-your system is not setup for `local delivery only`, you should set the
-`Reply-To` address for outgoing messages to a real e-mail account at
-your institution that is read regularly. You can do this by (all as
-_root_):
+. <<replyfilter,Reply-To filter>>[[replyfilter]]: If you follow the
+recommendation not to receive incoming mail and your system is not
+setup for `local delivery only`, you should set the `Reply-To` address
+for outgoing messages to a real e-mail account at your institution
+that is read regularly. You can do this by (all as _root_):
 
 +
-.. Create a file with contents
-(four lines):
+
+.. Create the filter (four lines in file):
+
 +
-./etc/exim4/reply-to-filter
-[source]
-----
+
++
+
+[subs="+quotes"]
+....
+cat >/etc/exim4/reply-to-filter <<EOF
 # Exim filter          << THIS LINE REQUIRED
 
 headers remove "Reply-To"
-headers add "Reply-To: email@address"
-----
+headers add "Reply-To: _email@address_"
+EOF
+....
+
 +
-Where `email@address` is the e-mail address you want replies to be
+
+Change `_email@address_` to the e-mail address you want replies to be
 addressed to. If you want more than one, separate them with commas.
 
-.. In _/etc/exim4/exim4.conf.template_, at the beginning of
-the file add (two lines):
 +
-....
-#set reply to
-system_filter = /etc/exim4/reply-to-filter
-....
+
+.. Create a file for local customizations:
+
+ touch /etc/exim4/conf.d/main/00-exim-localmacros
+ ln -sfn /etc/exim4/conf.d/main/00-exim-localmacros /etc/exim4/exim4.conf.localmacros
+
++
+
+NOTE: The file is constructed this way so that it will work for both
+non-split or split _exim4_ configurations.
+
+.. Add a call to the filter to _/etc/exim4/exim4.conf.localmacros_:
+
+ cat >>/etc/exim4/exim4.conf.localmacros <<EOF
+ #set reply to
+ system_filter = /etc/exim4/reply-to-filter
+ EOF
+
++
 
 .. Then execute
 
-    update-exim4.conf
-    systemctl restart exim4
+ update-exim4.conf
+ systemctl restart exim4
 
 . You should change your _/etc/aliases_ so _root_ and _prog_ e-mail goes to _oper_.
 
@@ -1443,20 +1463,30 @@ sure to change the owner of the file to be _oper_.
 
 If mail from your system is being rejected by some servers because
 _exim4_ is not providing a Fully Qualified Domain Name (FQDN), in its `HELO`
-message, the following solution should fix the problem.
+message, the following steps should fix the problem.
 
-Add the following line to the beginning of _/etc/exim4/exim4.conf.template_:
 
-....
-MAIN_HARDCODE_PRIMARY_HOSTNAME=ETC_MAILNAME
-....
+. If you have not already created
+_/etc/exim4/conf.d/main/00-exim-localmacros_ (see
+<<replyfilter,Reply-To filter>> above), do so:
 
-Then execute:
+ touch /etc/exim4/conf.d/main/00-exim-localmacros
+ ln -sfn /etc/exim4/conf.d/main/00-exim-localmacros /etc/exim4/exim4.conf.localmacros
 
-....
-update-exim4.conf
-systemctl restart exim4
-....
+. Add the necessary line to the file:
+
+ cat >>/etc/exim4/exim4.conf.localmacros <<EOF
+ MAIN_HARDCODE_PRIMARY_HOSTNAME=ETC_MAILNAME
+ EOF
+
+. Then execute:
+
+ update-exim4.conf
+ systemctl restart exim4
+
+. Verify that the change has taken effect:
+
+ exim4 -bP primary_hostname
 
 === Set X display resolution at boot
 

--- a/installation.adoc
+++ b/installation.adoc
@@ -21,7 +21,7 @@
 
 = FS Linux 11 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 0.0.30 - October 2022
+Version 0.0.31 - October 2022
 
 :sectnums:
 :experimental:
@@ -340,10 +340,25 @@ to confirm forcing UEFI installation.
 
 . When prompted for a partitioning method, select `Manual`
 
-. If needed, create a new partition table by:
+==== Setup physical partitions
+
+. Create a new partition table by:
 
 .. Select your disk, something like `SCSI1 (0,0,0) (sda) - 4 TB ATA
-SATA HARDDISK`, and press kbd:[Enter]
+SATA HARDDISK`, and press kbd:[Enter].
+
++
+
++
+
+WARNING: Do _not_ select your installation media.
+
+.. The installer may warn: `You have selected an entire device to
+partition…`. If so, select `Yes`.
+
+.. If you are prompted to delete RAID partitions, select `Yes`.
+
+. Select the (one and only entry) `FREE SPACE` under your disk.
 
 +
 
@@ -352,31 +367,46 @@ SATA HARDDISK`, and press kbd:[Enter]
 [NOTE]
 ====
 
-If some other file system, like `xfs`, or other old setup is
-displayed, you will need to delete it first. You may be able to do
-this by deleting individual partitions until you have a single `FREE
-SPACE` area. For more complicated layouts, it may be more expedient,
-and it may be necessary, to use `Guided partitioning` to delete the
-existing configuration (and temporarily create new partitions). In
-this case, select `Guided partitioning`, then select `Guided - use
-entire disk`. Then select your disk, such as listed above, do not
-select a RAID or your installation media device. Then select `All
-files in one partition (recommended for new users)`. You may be
-prompted to confirm deleting RAID partitions and/or removing logical
-volume data, which you must do to continue. Then you should be able to
-continue with selecting your disk, as above.
+If you have other entries and/or you have RAID or LVM partitions, you
+will need to delete the other entries before proceeding.
 
-If you have problems later creating the RAID or LVM partitions, then
-other means, such as exotic paths through the partitioner or writing a
-large number (perhaps 10 GB) of zeros at the start of the disk, may be
-necessary.
+If you do _not_ have any RAID or LVM partitions shown, a possible
+solution may be to delete individual partitions until you have a
+single entry, `FREE SPACE`.
+
+If that doesn't work or RAID and/or LVM partitions are shown, you may
+be able to use `Guided partitioning` to delete the existing
+configuration (and temporarily create new partitions). In this case,
+select `Guided partitioning`, then select `Guided - use entire disk`.
+Then select your disk, such as listed above, do _not_ select a RAID or
+your installation media device. Then select `All files in one
+partition (recommended for new users)`. You may be prompted to confirm
+deleting RAID partitions and/or removing logical volume data, which
+you must do to continue. Then you should be able to continue with
+selecting your disk, as above.
+
+If the `Guided partitioning` method above doesn't work or you have
+problems later creating the RAID or LVM partitions, then other means
+will be needed. There may be more complicated paths through the
+partitioner that will work or you may need to overwrite the start of
+the disk with a large number, say 2 GiB (but possibly more), of zeros.
+
+<<zeros,Overwriting with zeros>>[[zeros]]: can be implemented (for 2
+GiB) at this stage in the installer with:
+
+. Press kbd:[Ctrl+Alt+F2] to switch to a different console.
+
+. Press kbd:[Enter] to activate the console.
+
+. Execute:
+
+ dd if=/dev/zero of=/dev/sda bs=1G count=2
+ sync;sync
+ reboot
+
+. When the system reboots, restart the installation.
 
 ====
-
-.. The installer may warn: `You have selected an entire device to
-partition…`. If so, select `Yes`
-
-. Select the `FREE SPACE` under your disk.
 
 . Select `Create a new partition`
 
@@ -410,19 +440,34 @@ However, please note that a single disk setup is not recommended for any _operat
 ==== Setup RAID
 
 . Select `Configure software RAID`. Then select `Yes` to write the
-  changes to the disks.
+  changes to the disk.
 
-. Select `Create MD device`, choose `RAID1` and enter `*2*` as number
-of devices and `*0*` as number of spares.
+. Select `Create MD device`, choose `RAID1` and use `*2*` as the
+number of devices and `*0*` as the number of spares.
 
-. Select the RAID partition we just created by pressing kbd:[Space].
-This should be _sda2_. Then press kbd:[Enter] to continue. Select
-`yes` if prompted to write changes to disk.
+. Despite the fact that the instructions say you must select exactly
+two partitions, select only one. Select the RAID partition you just
+created by pressing kbd:[Space]. This should be _/dev/sda2_. Then
+press kbd:[Enter] to continue. Select `yes` if prompted to write
+changes to the disk.
+
++
+
+NOTE: If the newly created RAID partition doesn't appear as an option,
+you may need to use the method of <<zeros,Overwriting with zeros>> in
+the <<Setup physical partitions>> step above.
 
 . Select `Finish`.
 
-. Back in partitioning, select the (unassigned) partition `#1` _under_
+. Back in partitioning, select the partition `#1` (with no designated use) _under_
 `RAID1 device #0` and press kbd:[Enter]
+
++
+
+NOTE: If that partition appears immediately after being created
+already having a designated use, perhaps `lvm`, you may need to use
+the method of <<zeros,Overwriting with zeros>> in the
+<<Setup physical partitions>> sub-step above.
 
 . Select `Use as`, then select `physical volume for LVM`, then `Done
 setting up the partition`
@@ -430,8 +475,8 @@ setting up the partition`
 ==== Setup Logical Volume Manager (LVM)
 
 . Now choose `Configure the Logical Volume Manager` and select `Yes`
-if prompted to write the changes to disk or to keep the current layout
-and configure LVM.
+if prompted to write the changes to the disk and keep the current
+layout and configure LVM.
 
 
 . Choose `Create volume group`
@@ -470,7 +515,7 @@ optional unless you are applying CIS hardening.
 . For the `swap` logical volume, select `Use as` then select `swap area`, followed by `Done setting up this partition`
 
 . Back in the partition screen, select `Finish partitioning and write changes to
-the disks` and select `Yes` to write the changes. For big disks, it may take
+the disk` and select `Yes` to write the changes. For big disks, it may take
 a little time to create the `ext4` file systems.
 
 The Debian base system is now installed from the installation media, which

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.11 - October 2022
+Version 0.0.12 - October 2022
 
 :sectnums:
 :experimental:
@@ -690,9 +690,10 @@ support the current RAID. This might be used to initialize a disk that
 will not be used in the current RAID. As before, use the `-A` option
 only will expert advice.
 
-The `-Z` option (for expert use only) will "`zap`" the partition
-tables with 1 MiB of zeros. Each additional `-Z` specified will double
-the number of zeros written. This option can be useful to force a disk
+The `-Z` option (for expert use only) will "`zap`" the partition table
+and the start of each individual partition with 1 MiB of zeros. Each
+additional `-Z` specified will double the number of zeros written to
+the individual partitions. This option may be useful to force a disk
 into a state that the installer can handle.
 
 NOTE: On the 32-bit _i386_ platform, due to a broken _vgremove_ binary, this

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.8 - October 2022
+Version 0.0.9 - October 2022
 
 :sectnums:
 :experimental:
@@ -598,6 +598,28 @@ refreshing, but it may be a little slow.
 The system can rebooted while the refresh is still active, as long as
 the neither disk is removed until it is finished. The refresh will
 resume automatically after the reboot.
+
+[NOTE]
+====
+
+If the _primary_ disk has a larger capacity than the _secondary_ and
+the latter is new or has been blanked (typically with
+_blank_secondary_), you may see a warning like:
+
+ Caution! Secondary header was placed beyond the disk's limits! Moving the
+ header, but other problems may occur!
+
+In this case, the message is benign and can be ignored _if_ the
+_primary_ disk has a partition layout that will fit on the smaller
+disk. This should be the case if the system was setup initially as
+described in the <<installation.adoc#,FS Linux 11 Installation Guide>>
+document and the _primary_ was most recently refreshed from a disk
+used in the RAID that has the partition layout of the smallest disk.
+This situation can occur if one (or more) of the disks is larger than
+the smallest one, perhaps because it was obtained as a replacement for
+a failed disk.
+
+====
 
 === blank_secondary
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.9 - October 2022
+Version 0.0.10 - October 2022
 
 :sectnums:
 :experimental:
@@ -658,6 +658,14 @@ _md0_`" check above, but is included out of an abundance of caution.
 
 . Has a partition that is included in any RAID.
 
+. Is smaller in size than the _primary_ disk
+
++
+
+This may be relaxed with the `-A` option, if the script is being used
+to blank a disk that will _not_ be used in this RAID.
+
+
 If the _primary_ disk is removable, the user will be provided with some
 information about the disk and given an opportunity to continue with
 kbd:[Enter] or abort with kbd:[Ctrl+C].  Typically, if a USB disk is
@@ -674,9 +682,20 @@ possible and must be used with extra care.
 
 If the disk is turned on (when prompted) during the script, it will
 automatically be "`Allowed`" by both this script and
-_refresh_secondary_, which also supports this feature.  This allows
-you to then run _refresh_secondary_ immediately without having to
-shutdown, turn the disk off, reboot, start the script, and turn the disk on.
+_refresh_secondary_, which also supports this feature. This allows you
+to then run _refresh_secondary_ immediately without having to
+shutdown, turn the disk off, reboot, start the script, and turn the
+disk on.
+
+The `-A` will also allow blanking of a disk that is too small to
+support the current RAID. This might be used to initialize a disk that
+will not be used in the current RAID. As before, use the `-A` option
+only will expert advice.
+
+The `-Z` option (for expert use only) will "`zap`" the partition
+tables with 1 MiB of zeros. Each additional `-Z` specified will double
+the number of zeros written. This option can be useful to force a disk
+into a state that the installer can handle.
 
 NOTE: On the 32-bit _i386_ platform, due to a broken _vgremove_ binary, this
 script can give WARNINGs when erasing disks that were used for LVM.  These

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.7 - October 2022
+Version 0.0.8 - October 2022
 
 :sectnums:
 :experimental:
@@ -353,7 +353,7 @@ The subsections below cover various scenarios for initializing one new
 disk to complete a set of three, i.e., one of three disks in a set has
 failed. It is assumed that you want to maintain the cyclic numbering
 of the disks for rotations (but that is not required). It should be
-straightforward to adapt them to other cases.
+straightforward to adapt the procedures for other cases.
 
 If you need to initialize more than one disk, please follow the
 instructions in the <<installation.adoc#_setup_additional_disks,Setup
@@ -369,7 +369,9 @@ This case corresponds to not having a good shelf disk.
 If the disks are in cyclical order (i.e., _primary_, _secondary_ are
 numbered in order: 1, 2, or 2, 3, or 3, 1), you should:
 
-. Take the disk from _primary_ slot, put it on the _shelf_
+. Take the disk from _primary_ slot, put it on the _shelf_, labeled
+with the date
+
 . Move the disk from the _secondary_ slot to the _primary_ slot, keyed-on
 
 If the disks are not in cyclical order (i.e., _primary_, _secondary_
@@ -772,7 +774,9 @@ or if any _missing_ disk:
 [start=3]
 . Has a later modification `TIME` than the _active_ disk
 . Has a higher `EVENT` count, i.e., is newer,  than the _active_ disk
-. Has been used (booted) separately (as mentioned above in the *WARNING* item)
+
+. Has been used (booted) separately (as mentioned above in the
+*IMPORTANT* item)
 
 or if no matching _missing_ disk can be found.
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.10 - October 2022
+Version 0.0.11 - October 2022
 
 :sectnums:
 :experimental:
@@ -613,11 +613,9 @@ In this case, the message is benign and can be ignored _if_ the
 _primary_ disk has a partition layout that will fit on the smaller
 disk. This should be the case if the system was setup initially as
 described in the <<installation.adoc#,FS Linux 11 Installation Guide>>
-document and the _primary_ was most recently refreshed from a disk
-used in the RAID that has the partition layout of the smallest disk.
-This situation can occur if one (or more) of the disks is larger than
-the smallest one, perhaps because it was obtained as a replacement for
-a failed disk.
+document. This situation can occur if one (or more) of the disks is
+larger than the smallest one, perhaps because it was obtained as a
+replacement for a failed disk.
 
 ====
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 0.0.6 - September 2022
+Version 0.0.7 - October 2022
 
 :sectnums:
 :experimental:
@@ -356,8 +356,8 @@ of the disks for rotations (but that is not required). It should be
 straightforward to adapt them to other cases.
 
 If you need to initialize more than one disk, please follow the
-instructions in the <<installation.adoc#_setup_additional_disk,Setup
-additional disk>> section of the <<installation.adoc#,FS Linux 11
+instructions in the <<installation.adoc#_setup_additional_disks,Setup
+additional disks>> subsection of the <<installation.adoc#,FS Linux 11
 Installation Guide>> document.
 
 === Currently two disks are running in the RAID


### PR DESCRIPTION
This PR has wording changes to limit the installation to using only one disk. This solves the problem of not knowing which device should be identified as the target for installing GRUB to the _secondary_disk_. That GRUB installation is now handled by a new "Fourth" stage that sets up additional disks with _blank_secondary_ and _refresh_secondary_ (the use of those were formerly part of the "Post Install" step). The result allows a faster install and is hopefully simpler.

Other improvements to the documents are included, but those are in separate commits to make it easier to identify the changes by topic.

Changes to make customizations of _exim4_ less invasive have not been included yet.