### PR TITLE
Disk age check when refreshing

### DIFF
--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2021, 2023 NVI, Inc.
+# Copyright (c) 2020-2021, 2023-2024 NVI, Inc.
 #
 # This file is part of FSL11 Linux distribution.
 # (see http://github.com/nvi-inc/fsl11).
@@ -189,6 +189,12 @@ if [ -b /dev/"$SDB"2 ] && [ "$(mdadm --examine /dev/"$SDB"2 | grep "Array State"
 	exit 1
 fi
 
+# Check age of "Secondary" disk
+if [ -b /dev/"$SDB"2 ] && [ $(( $(date +%s) - 86400 )) -lt $(mdadm --examine -Y /dev/"$SDB"2 | grep TIME | cut -d'=' -f2) ]; then
+	echo "SANITY CHECK: \"Secondary\" disk /dev/"$SDB"2 TIME is too recent."
+	echo "(You may want to use blank_secondary to erase the second disk first)"
+	exit 1
+fi
 
 # ------------- Everything looks sane so let's set to work ----------------
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020-2023 NVI, Inc.
+// Copyright (c) 2020-2024 NVI, Inc.
 //
 // This file is part of the FSL11 Linux distribution.
 // (see http://github.com/nvi-inc/fsl11).
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 11
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.0.1 - December 2023
+Version 1.0.2 - January 2024
 
 :sectnums:
 :experimental:
@@ -561,6 +561,15 @@ run on the other disks for more than a trivial amount of time
 beforehand.
 
 . Has been used (booted) separately by itself
+
+. Was last used less than 24 hours ago (a mis-set clock or clocks
+can invalidate this check).
+
++
+
+This is intended to prevent accidentally refreshing a new _shelf_
+disk.
+
 . Has a different partition layout from the _primary_
 . Is smaller than the size of the RAID on the _primary_ disk.
 


### PR DESCRIPTION
This PR tries to cleanup a couple small issues:

1. In _rotation_shutdown_, the prompt for confirming shutting down was moved to the start of the script. The goal being to avoid having a potential long delay (if the user doesn't respond to the prompt quicky) between verifying that shutting down is safe and the actual shutdown.
2. In _refresh_secondary_, the age of the secondary disk is checked. If it is less than three hours old, the refresh is aborted. The idea is catch if the operator accidentally inserted the _new_ shelf disk by mistake. Using _blank_secondary_ is a way for an expert to override this check.
 
I am not sure what the best age limit is in _refresh_secondary_. If it is too short, the operator can keep trying to run the script (without thinking about it) until it succeeds. If it is too long, it might interfere with some tasks like doing another rotation to get the disks in the correct cyclical order. OTOH, an operator would probably not be doing such tasks. This might argue for a larger limit, maybe a day or even a week or two (assuming rotations are done monthly). Also a longer limit would allow more time for an expert to look into what went wrong. For now I left it at three hours. A refresh of a 2 TB disk takes a bit longer than this, so after the refresh the operator could do another rotation without special measures. It is long enough that the check won't be overridden unless the operator is really determined. Anyway, it shouldn't happen by accident.

These two commit are disjoint. Unless the branch gets more complicated, it can probably be FF'd onto _main_ when it is ready.

A question is whether these (and other accumulated changes) are enough to have a minor release. In any event, a user could update by pulling _main_ and running _RAID/install_tools_.
